### PR TITLE
Fix link error and function name

### DIFF
--- a/ch03/sigmoid/main/sigmoid.cc
+++ b/ch03/sigmoid/main/sigmoid.cc
@@ -9,6 +9,6 @@
 using namespace std;
 
 template <typename T>
-T And(const T& x) {
-    return 1 / (1 + exp(x));
+T sigmoid(const T& x) {
+    return 1 / (1 + exp(-x));
 }

--- a/ch03/sigmoid/toolchain/cc_toolchain_config.bzl
+++ b/ch03/sigmoid/toolchain/cc_toolchain_config.bzl
@@ -77,6 +77,8 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
+                                "-lm",
+                                "-ldl",
                                 "-lstdc++",
                                 "-pg",
                                 "-Og",


### PR DESCRIPTION
cmath will resole symbols in  `-lm -ldl`

show [undefined reference to symbol 'exp@@GLIBC_X.X.X'](https://askubuntu.com/questions/527665/undefined-reference-to-symbol-expglibc-2-2-5)
